### PR TITLE
Fixed "status" object missing from result of sync job sumit

### DIFF
--- a/src/main/java/org/khaleesi/carfield/tools/sparkjobserver/api/SparkJobServerClientImpl.java
+++ b/src/main/java/org/khaleesi/carfield/tools/sparkjobserver/api/SparkJobServerClientImpl.java
@@ -547,8 +547,16 @@ class SparkJobServerClientImpl implements ISparkJobServerClient {
 	private SparkJobResult parseResult(String resContent) throws Exception {
 		JSONObject jsonObj = JSONObject.fromObject(resContent);
 		SparkJobResult jobResult = new SparkJobResult(resContent);
-		jobResult.setStatus(jsonObj.getString(SparkJobBaseInfo.INFO_KEY_STATUS));
-		if (SparkJobBaseInfo.COMPLETED.contains(jobResult.getStatus())) {
+		boolean completed = false;
+		if(jsonObj.has(SparkJobBaseInfo.INFO_KEY_STATUS)) {
+			jobResult.setStatus(jsonObj.getString(SparkJobBaseInfo.INFO_KEY_STATUS));
+			if (SparkJobBaseInfo.COMPLETED.contains(jobResult.getStatus())) {
+				completed = true;
+			}
+		} else {
+			completed = true;
+		}
+		if (completed) {
 			//Job finished with results
 			jobResult.setResult(jsonObj.get(SparkJobBaseInfo.INFO_KEY_RESULT).toString());
 		} else if (containsAsynjobStatus(jsonObj)) {


### PR DESCRIPTION
The 'status' element is missing from the results of job submit when it is a synchronous call. This was throwing an exception. Added a check to see if the status element exists.

https://github.com/bluebreezecf/SparkJobServerClient/issues/6