### PR TITLE
Kill a Job from SJS Java client

### DIFF
--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/ISparkJobServerClient.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/ISparkJobServerClient.java
@@ -285,7 +285,7 @@ public interface ISparkJobServerClient {
 	 * Kill the specified job
 	 *
 	 * <p>
-	 * This method implements the Rest API <code>'POST /jobs' </code> of the Spark
+	 * This method implements the Rest API <code>'DELETE /jobs/&lt;jobId&gt' </code> of the Spark
 	 * Job Server.
 	 *
 	 * @param jobId the id of the target job.

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/ISparkJobServerClient.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/ISparkJobServerClient.java
@@ -280,4 +280,20 @@ public interface ISparkJobServerClient {
 	 *         information of the target job configuration
 	 */
 	SparkJobConfig getConfig(String jobId) throws SparkJobServerClientException;
+
+	/**
+	 * Kill the specified job
+	 *
+	 * <p>
+	 * This method implements the Rest API <code>'POST /jobs' </code> of the Spark
+	 * Job Server.
+	 *
+	 * @param jobId the id of the target job.
+	 *
+	 * @return the corresponding killed job status or killed job result
+	 * @throws SparkJobServerClientException if failed to kill a job,
+	 *        or I/O error occurs when trying to kill existing job
+	 */
+	boolean killJob(String jobId) throws SparkJobServerClientException;
+
 }

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/ISparkJobServerClient.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/ISparkJobServerClient.java
@@ -144,6 +144,21 @@ public interface ISparkJobServerClient {
 	 *         information of jobs
 	 */
 	List<SparkJobInfo> getJobs() throws SparkJobServerClientException;
+
+	/**
+	 * Lists the last N jobs in the Spark Job Server for the specified job status.
+	 *
+	 * <p>
+	 * This method implements the Rest API <code>'GET /jobs&quest;status&equals;&lpar;RUNNING&verbar;ERROR&verbar;FINISHED&verbar;
+	 * STARTED&verbar;OK&rpar;' </code> of the Spark
+	 * Job Server.
+	 *</p>
+	 * @param jobStatus RUNNING OK ERROR FINISHED STARTED
+	 * @return a list containing information of the jobs for specified status
+	 * @throws SparkJobServerClientException error occurs when trying to get
+	 *         information of jobs
+	 */
+	List<SparkJobInfo> getJobsByStatus(String jobStatus) throws SparkJobServerClientException;
 	
 	/**
 	 * Start a new job with the given parameters.

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
@@ -74,7 +74,35 @@ public final class SparkJobServerClientFactory {
 		}
 		return sparkJobServerClient;
 	}
-	
+
+	/**
+	 * Creates an instance of <code>ISparkJobServerClient</code> with the given url, username and password.
+	 *
+	 * @param url the url of the target Spark Job Server
+	 * @param jobServerUsername the username for authentication of target Spark Job Server
+	 * @param jobServerPassword the password for authentication of the target Spark Job Server
+	 * @return the corresponding <code>ISparkJobServerClient</code> instance
+	 * @throws SparkJobServerClientException error occurs when trying to create the
+	 *     target spark job server client
+	 */
+	public ISparkJobServerClient createSparkJobServerClient(String url,String jobServerUsername,String jobServerPassword)
+			throws SparkJobServerClientException {
+		if (!isValidUrl(url)) {
+			throw new SparkJobServerClientException("Invalid url can't be used to create a spark job server client.");
+		}
+		if(jobServerUsername == null || jobServerUsername.isEmpty()){
+			throw new SparkJobServerClientException("Invalid username can't be null or empty.");
+		}
+		String sparkJobServerUrl = url.trim();
+		jobServerUsername = jobServerUsername.trim();
+		ISparkJobServerClient sparkJobServerClient = jobServerClientCache.get(sparkJobServerUrl+"_@_"+jobServerUsername+"_@_"+jobServerPassword);
+		if (null == sparkJobServerClient) {
+			sparkJobServerClient = new SparkJobServerClientImpl(url,jobServerUsername,jobServerPassword);
+			jobServerClientCache.put(sparkJobServerUrl+"_@_"+jobServerUsername+"_@_"+jobServerPassword, sparkJobServerClient);
+		}
+		return sparkJobServerClient;
+	}
+
 	/**
 	 * Checks the given url is valid or not.
 	 * 

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
@@ -90,7 +90,7 @@ public final class SparkJobServerClientFactory {
 		if (!isValidUrl(url)) {
 			throw new SparkJobServerClientException("Invalid url can't be used to create a spark job server client.");
 		}
-		if(jobServerUsername == null || jobServerUsername.isEmpty()){
+		if(jobServerUsername == null || jobServerUsername.isEmpty()) {
 			throw new SparkJobServerClientException("Invalid username can't be null or empty.");
 		}
 		String sparkJobServerUrl = url.trim();

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
@@ -85,20 +85,20 @@ public final class SparkJobServerClientFactory {
 	 * @throws SparkJobServerClientException error occurs when trying to create the
 	 *     target spark job server client
 	 */
-	public ISparkJobServerClient createSparkJobServerClient(String url,String jobServerUsername,String jobServerPassword)
-			throws SparkJobServerClientException {
+	public ISparkJobServerClient createSparkJobServerClient(String url, String jobServerUsername,
+        String jobServerPassword) throws SparkJobServerClientException {
 		if (!isValidUrl(url)) {
 			throw new SparkJobServerClientException("Invalid url can't be used to create a spark job server client.");
 		}
-		if(jobServerUsername == null || jobServerUsername.isEmpty()) {
+		if (jobServerUsername == null || jobServerUsername.isEmpty()) {
 			throw new SparkJobServerClientException("Invalid username can't be null or empty.");
 		}
 		String sparkJobServerUrl = url.trim();
 		jobServerUsername = jobServerUsername.trim();
-		ISparkJobServerClient sparkJobServerClient = jobServerClientCache.get(sparkJobServerUrl+"_@_"+jobServerUsername+"_@_"+jobServerPassword);
+		ISparkJobServerClient sparkJobServerClient = jobServerClientCache.get(sparkJobServerUrl + "_@_" + jobServerUsername + "_@_" + jobServerPassword);
 		if (null == sparkJobServerClient) {
-			sparkJobServerClient = new SparkJobServerClientImpl(url,jobServerUsername,jobServerPassword);
-			jobServerClientCache.put(sparkJobServerUrl+"_@_"+jobServerUsername+"_@_"+jobServerPassword, sparkJobServerClient);
+			sparkJobServerClient = new SparkJobServerClientImpl(url, jobServerUsername, jobServerPassword);
+			jobServerClientCache.put(sparkJobServerUrl + "_@_" + jobServerUsername + "_@_" + jobServerPassword, sparkJobServerClient);
 		}
 		return sparkJobServerClient;
 	}

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientImpl.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientImpl.java
@@ -32,8 +32,21 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.log4j.Logger;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Base64;
 import java.util.stream.Collectors;
 
 /**
@@ -79,7 +92,7 @@ class SparkJobServerClientImpl implements ISparkJobServerClient {
 	 * {@inheritDoc}
 	 */
 	public List<SparkJobJarInfo> getJars() throws SparkJobServerClientException {
-		List<SparkJobJarInfo> sparkJobJarInfos = new ArrayList<SparkJobJarInfo>();
+		List<SparkJobJarInfo> sparkJobJarInfos = new ArrayList<>();
 		final CloseableHttpClient httpClient = buildClient();
 		try {
 			HttpGet getMethod = new HttpGet(jobServerUrl + "jars");
@@ -204,7 +217,7 @@ class SparkJobServerClientImpl implements ISparkJobServerClient {
 	/**
 	 * {@inheritDoc}
 	 */
-	public boolean createContext(String contextName, Map<String, String> params) 
+	public boolean createContext(String contextName, Map<String, String> params)
 		throws SparkJobServerClientException {
 		final CloseableHttpClient httpClient = buildClient();
 		try {


### PR DESCRIPTION
This killJob method implements the kill job REST API (DELETE jobs/<jobid>) supported by the Spark Job Server.