### PR TITLE
Support for Spark Job Server 0.9, Connection Timeouts

### DIFF
--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobInfo.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobInfo.java
@@ -47,10 +47,18 @@ public class SparkJobInfo extends SparkJobBaseInfo {
 	 * The value shows start time of the target spark job.
 	 */
 	static final String INFO_KEY_START_TIME = "startTime";
+
+	/**
+	 * Id of Context information in the Spark Job Server's json response.
+	 * <p>
+	 * The value shows Unique Identification for the context of the target spark job.
+	 */
+	static final String INFO_CONTEXT_ID = "contextId";
 	
 	private String duration;
 	private String classPath;
 	private String startTime;
+	private String contextId;
 
 	
 	public String getDuration() {
@@ -71,6 +79,12 @@ public class SparkJobInfo extends SparkJobBaseInfo {
 	void setStartTime(String startTime) {
 		this.startTime = startTime;
 	}
+	public String getContextId() {
+		return contextId;
+	}
+	void setContextId(String contextId) {
+		this.contextId = contextId;
+	}
 	
 	/**
 	 * {@inheritDoc}
@@ -90,7 +104,9 @@ public class SparkJobInfo extends SparkJobBaseInfo {
 			.append(" ").append(INFO_KEY_JOB_ID).append(": ")
 			.append(this.getJobId() != null ? this.getJobId() : INFO_EMPTY_VALUE).append("\n")
 			.append(" ").append(INFO_KEY_STATUS).append(": ")
-			.append(this.getStatus() != null ? this.getStatus() : INFO_EMPTY_VALUE).append("\n");
+			.append(this.getStatus() != null ? this.getStatus() : INFO_EMPTY_VALUE).append("\n")
+			.append(" ").append(INFO_CONTEXT_ID).append(": ")
+			.append(this.getContextId() != null ? this.getContextId() : INFO_EMPTY_VALUE).append("\n");
 		if (this.getMessage() != null) {
 			buff.append(" ").append(INFO_KEY_RESULT).append(": {\n")
 				.append("  ").append(INFO_KEY_RESULT_MESSAGE).append(": ").append(getMessage()).append("\n");

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientFactory.java
@@ -103,6 +103,44 @@ public final class SparkJobServerClientFactory {
 		return sparkJobServerClient;
 	}
 
+    /**
+     * Creates an instance of <code>ISparkJobServerClient</code> with the given
+     * url, username and password and Http Connection, Request, Socket Timeouts
+     *
+     * @param url the url of the target Spark Job Server
+     * @param jobServerUsername the username for authentication of target Spark Job Server
+     * @param jobServerPassword the password for authentication of the target Spark Job Server
+     * @param connectionTimeOut
+     * @param connectionReqTimeOut
+     * @param socketTimeOut
+     * @return the corresponding <code>ISparkJobServerClient</code> instance
+     * @throws SparkJobServerClientException error occurs when trying to create the
+     *     target spark job server client
+     */
+    public ISparkJobServerClient createSparkJobServerClient(String url, String jobServerUsername,
+                                                            String jobServerPassword, Integer connectionTimeOut,
+                                                            Integer connectionReqTimeOut,
+                                                            Integer socketTimeOut) throws SparkJobServerClientException {
+        if (!isValidUrl(url)) {
+            throw new SparkJobServerClientException("Invalid url can't be used to create a spark job server client.");
+        }
+        if (jobServerUsername == null || jobServerUsername.isEmpty()) {
+            throw new SparkJobServerClientException("Invalid username can't be null or empty.");
+        }
+        String sparkJobServerUrl = url.trim();
+        jobServerUsername = jobServerUsername.trim();
+        String cacheKey = sparkJobServerUrl + "_@_" + jobServerUsername
+                + "_@_" + jobServerPassword + "_@_" + connectionTimeOut + "_@_" + connectionReqTimeOut +
+                "_@_" + socketTimeOut;
+        ISparkJobServerClient sparkJobServerClient = jobServerClientCache.get(cacheKey);
+        if (null == sparkJobServerClient) {
+            sparkJobServerClient = new SparkJobServerClientImpl(url, jobServerUsername, jobServerPassword,
+                    connectionTimeOut, connectionReqTimeOut, socketTimeOut);
+            jobServerClientCache.put(cacheKey, sparkJobServerClient);
+        }
+        return sparkJobServerClient;
+    }
+
 	/**
 	 * Checks the given url is valid or not.
 	 * 

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientImpl.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientImpl.java
@@ -103,9 +103,9 @@ class SparkJobServerClientImpl implements ISparkJobServerClient {
 			jobServerUrl = jobServerUrl + "/";
 		}
 		this.jobServerUrl = jobServerUrl;
-		this.socketTimeOut = connectionTimeOut == null? DEFAULT_SOCKET_TIMEOUT : connectionTimeOut;
+		this.socketTimeOut = connectionTimeOut == null? DEFAULT_CONNECTION_TIMEOUT : connectionTimeOut;
 		this.connectionReqTimeOut = connectionReqTimeOut == null ? DEFAULT_REQUEST_TIMEOUT : connectionReqTimeOut;
-		this.connectionTimeOut = socketTimeOut == null ? DEFAULT_CONNECTION_TIMEOUT : socketTimeOut;
+		this.connectionTimeOut = socketTimeOut == null ? DEFAULT_SOCKET_TIMEOUT : socketTimeOut;
 	}
 
     /**

--- a/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientImpl.java
+++ b/src/main/java/com/bluebreezecf/tools/sparkjobserver/api/SparkJobServerClientImpl.java
@@ -103,9 +103,9 @@ class SparkJobServerClientImpl implements ISparkJobServerClient {
 			jobServerUrl = jobServerUrl + "/";
 		}
 		this.jobServerUrl = jobServerUrl;
-		this.socketTimeOut = connectionTimeOut == null? DEFAULT_CONNECTION_TIMEOUT : connectionTimeOut;
+		this.socketTimeOut = socketTimeOut == null ? DEFAULT_SOCKET_TIMEOUT : socketTimeOut;
 		this.connectionReqTimeOut = connectionReqTimeOut == null ? DEFAULT_REQUEST_TIMEOUT : connectionReqTimeOut;
-		this.connectionTimeOut = socketTimeOut == null ? DEFAULT_SOCKET_TIMEOUT : socketTimeOut;
+		this.connectionTimeOut = connectionTimeOut == null ? DEFAULT_CONNECTION_TIMEOUT : connectionTimeOut;
 	}
 
     /**


### PR DESCRIPTION
Support for Spark Job Server 0.9 ([SJS 0.9 Release Notes](https://github.com/spark-jobserver/spark-jobserver/releases))
     - Added support for additional key contextId in Job Response 
Support for TimeOuts while creating Connection for Requests to Spark Job Server.
    - Set Connection TImeout
    - Set Connection Request Timeout
    - Set Socket Timeout
Set Authorization Moved to Util Method.
Create Spark Job Info Moved to Util method.